### PR TITLE
refactor: speed up addres list GRAR-1367

### DIFF
--- a/src/AddressRegistry.Api.Legacy/Address/Query/AddressListQuery.cs
+++ b/src/AddressRegistry.Api.Legacy/Address/Query/AddressListQuery.cs
@@ -55,15 +55,23 @@ namespace AddressRegistry.Api.Legacy.Address.Query
             {
                 var searchName = filtering.Filter.MunicipalityName.RemoveDiacritics();
 
-                streetnames =
-                    from s in streetnames
-                    join m in municipalities.Where(m =>
-                            m.NameDutchSearch == searchName ||
-                            m.NameFrenchSearch == searchName ||
-                            m.NameGermanSearch == searchName ||
-                            m.NameEnglishSearch == searchName)
-                        on s.NisCode equals m.NisCode
-                    select s;
+                var niscode = municipalities.SingleOrDefault(m =>
+                    m.NameDutchSearch == searchName ||
+                    m.NameFrenchSearch == searchName ||
+                    m.NameGermanSearch == searchName ||
+                    m.NameEnglishSearch == searchName)?.NisCode ?? "XXX";
+
+                streetnames = streetnames.Where(x => x.NisCode == niscode);
+
+                //streetnames =
+                //    from s in streetnames
+                //    join m in municipalities.Where(m =>
+                //            m.NameDutchSearch == searchName ||
+                //            m.NameFrenchSearch == searchName ||
+                //            m.NameGermanSearch == searchName ||
+                //            m.NameEnglishSearch == searchName)
+                //        on s.NisCode equals m.NisCode
+                //    select s;
 
                 filterStreet = true;
             }
@@ -71,6 +79,7 @@ namespace AddressRegistry.Api.Legacy.Address.Query
             if (!string.IsNullOrEmpty(filtering.Filter.StreetName))
             {
                 var searchName = filtering.Filter.StreetName.RemoveDiacritics();
+
                 streetnames = streetnames.Where(s =>
                     s.NameDutchSearch == searchName ||
                     s.NameFrenchSearch == searchName ||
@@ -93,11 +102,15 @@ namespace AddressRegistry.Api.Legacy.Address.Query
 
             if (filterStreet)
             {
-                addresses =
-                    from a in addresses
-                    join s in streetnames
-                        on a.StreetNameId equals s.StreetNameId
-                    select a;
+                addresses = addresses
+                    .Where(x => streetnames
+                        .Select(y => y.StreetNameId).Contains(x.StreetNameId));
+
+                //addresses =
+                //    from a in addresses
+                //    join s in streetnames
+                //        on a.StreetNameId equals s.StreetNameId
+                //    select a;
             }
 
             return addresses;


### PR DESCRIPTION
Transform the following SQL:

```sql
SELECT COUNT(*)
FROM (
    SELECT [a].[AddressId], [a].[BoxNumber], [a].[Complete], [a].[HouseNumber], [a].[PersistentLocalId], [a].[PostalCode], [a].[Removed], [a].[Status], [a].[StreetNameId], [a].[VersionTimestamp], [t0].[StreetNameId] AS [StreetNameId0], [t0].[MunicipalityId]
    FROM [AddressRegistryLegacy].[AddressList] AS [a]
    INNER JOIN (
        SELECT [s].[StreetNameId], [s].[HomonymAdditionDutch], [s].[HomonymAdditionEnglish], [s].[HomonymAdditionFrench], [s].[HomonymAdditionGerman], [s].[IsComplete], [s].[IsRemoved], [s].[NameDutch], [s].[NameDutchSearch], [s].[NameEnglish], [s].[NameEnglishSearch], [s].[NameFrench], [s].[NameFrenchSearch], [s].[NameGerman], [s].[NameGermanSearch], [s].[NisCode], [s].[PersistentLocalId], [s].[Position], [s].[Version], [t].[MunicipalityId], [t].[NameDutch] AS [NameDutch0], [t].[NameDutchSearch] AS [NameDutchSearch0], [t].[NameEnglish] AS [NameEnglish0], [t].[NameEnglishSearch] AS [NameEnglishSearch0], [t].[NameFrench] AS [NameFrench0], [t].[NameFrenchSearch] AS [NameFrenchSearch0], [t].[NameGerman] AS [NameGerman0], [t].[NameGermanSearch] AS [NameGermanSearch0], [t].[NisCode] AS [NisCode0], [t].[Position] AS [Position0], [t].[PrimaryLanguage], [t].[Version] AS [Version0]
        FROM [AddressRegistrySyndication].[StreetNameLatestSyndication] AS [s]
        INNER JOIN (
            SELECT [m].[MunicipalityId], [m].[NameDutch], [m].[NameDutchSearch], [m].[NameEnglish], [m].[NameEnglishSearch], [m].[NameFrench], [m].[NameFrenchSearch], [m].[NameGerman], [m].[NameGermanSearch], [m].[NisCode], [m].[Position], [m].[PrimaryLanguage], [m].[Version]
            FROM [AddressRegistrySyndication].[MunicipalityLatestSyndication] AS [m]
            WHERE ((([m].[NameDutchSearch] = @__searchName_0) OR ([m].[NameFrenchSearch] = @__searchName_0)) OR ([m].[NameGermanSearch] = @__searchName_0)) OR ([m].[NameEnglishSearch] = @__searchName_0)
        ) AS [t] ON [s].[NisCode] = [t].[NisCode]
        WHERE ([s].[IsComplete] = CAST(1 AS bit)) AND ([s].[IsRemoved] <> CAST(1 AS bit))
    ) AS [t0] ON [a].[StreetNameId] = [t0].[StreetNameId]
    WHERE (([a].[Complete] = CAST(1 AS bit)) AND ([a].[Removed] <> CAST(1 AS bit))) AND ([a].[PersistentLocalId] <> 0)
    ORDER BY [a].[PersistentLocalId]
    OFFSET 0 ROWS FETCH NEXT @__p_1 ROWS ONLY
) AS [t1]
```

Into this:

```sql
SELECT COUNT(*)
FROM (
    SELECT [a].[AddressId], [a].[BoxNumber], [a].[Complete], [a].[HouseNumber], [a].[PersistentLocalId], [a].[PostalCode], [a].[Removed], [a].[Status], [a].[StreetNameId], [a].[VersionTimestamp]
    FROM [AddressRegistryLegacy].[AddressList] AS [a]
    WHERE ((([a].[Complete] = CAST(1 AS bit)) AND ([a].[Removed] <> CAST(1 AS bit))) AND ([a].[PersistentLocalId] <> 0)) AND [a].[StreetNameId] IN (
        SELECT [s].[StreetNameId]
        FROM [AddressRegistrySyndication].[StreetNameLatestSyndication] AS [s]
        WHERE (([s].[IsComplete] = CAST(1 AS bit)) AND ([s].[IsRemoved] <> CAST(1 AS bit))) AND ([s].[NisCode] = @__niscode_0)
    )

    ORDER BY [a].[PersistentLocalId]
    OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
) AS [t]
```